### PR TITLE
Robustify group list parsing

### DIFF
--- a/src/main/java/io/jenkins/plugins/jwt_auth/JwtAuthSecurityRealm.java
+++ b/src/main/java/io/jenkins/plugins/jwt_auth/JwtAuthSecurityRealm.java
@@ -245,7 +245,7 @@ public class JwtAuthSecurityRealm extends SecurityRealm {
 						groups = jwtClaims.getStringListClaimValue(groupsClaimName);
 					} else {
 						String groupList = jwtClaims.getClaimValueAsString(groupsClaimName);
-						groups = Arrays.asList(StringUtils.splitPreserveAllTokens(groupList, groupsClaimSeparator));
+						groups = Arrays.asList(StringUtils.split(groupList, groupsClaimSeparator));
 					}
 
 					if (groups == null) {

--- a/src/test/java/io/jenkins/plugins/jwt_auth/JwtAuthSecurityRealmTest.java
+++ b/src/test/java/io/jenkins/plugins/jwt_auth/JwtAuthSecurityRealmTest.java
@@ -155,6 +155,22 @@ public class JwtAuthSecurityRealmTest {
                         "group1|group2|group3",
                         false
                 },
+                // Azure passes groups as [group1, group2, group3]
+                new Object[]{
+                        "http://localhost:9191/.well-known/jwks.json",
+                        "",
+                        "",
+                        "other-header-NAME",
+                        "username",
+                        "string-group-field",
+                        ", []",
+                        ecJwk,
+                        "testuser",
+                        "testuser",
+                        Arrays.asList("group1", "group2", "group3"),
+                        "[group1, group2, group3]",
+                        false
+                },
                 // no jwks defined in the realm
                 new Object[]{
                         "",


### PR DESCRIPTION
Fix for #2 + unit test, minimal code changes.

When using Azure-AD -> AWS Cognito -> Jenkins with this plugin, the list of (Azure-AD) groups arrives at Jenkins as a String, not a List, and the String is of the form `[groupUuid1, groupUuid2, groupUuid3]`.
A "reasonable expectation" would be that, in such a usecase, telling this plugin to use separator characters `, []` would result in groups `groupUuid1`, `groupUuid2` and `groupUuid3` ... so that's what this PR allows.
(where the string starts or ends with separator characters, or contains multiple separator characters in a row, the empty "groups" that would previously have resulted from that are suppressed; previously parsing failed because empty groups aren't permitted).

TL;DR: Because empty groups aren't permitted anyway, suppressing them allows things to work where it would've previously failed.