### PR TITLE
Allow JWKS keys to be read from a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The plugin allows to
 * It have a "bearer " prefix or not, both is accepted
 * The mapping of username and group list to the claims can be customized (you can choose which claims to read)
 * Define a JWKS URL to verify the token. JWKS allows key rotation as needed.
+* Optional fallback to a JWKS file specified by the `JENKINS_JWT_AUTH_JWKSFILE` environment variable.
 
 Currently, JWKS is the only way to verify a token.
 

--- a/src/main/webapp/help/params/jwksjsonurl-help.html
+++ b/src/main/webapp/help/params/jwksjsonurl-help.html
@@ -7,8 +7,13 @@
   </p>
 
   <p>
-    Please be aware that if you <strong>don't</strong> provide a JWKS URL, no signature verification will be performed.
-    This is useful for use cases that use JWT but don't sign them.
+    If left unset, and the environment variable <code>JENKINS_JWT_AUTH_JWKSFILE</code> is set to a valid file path, the
+    signing keys will be read from this file.
+  </p> 
+
+  <p>
+    Please be aware that if you <strong>don't</strong> provide a JWKS URL, and you <strong>don't</strong> provide a JWKS file,
+    no signature verification will be performed. This is useful for use cases that use JWT but don't sign them.
   </p>
 
   <p>


### PR DESCRIPTION
Allow JWKS keys to be read from a file. The file is specified with the JENKINS_JWT_AUTH_JWKSFILE environment variable, and is used when an URL is not specified.

### Testing done

JwtAuthSecurityRealmTest updated to test both file as a source in addition to mocked URL.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
