### PR TITLE
Avoid NullPointerException when groups claim is missing

### DIFF
--- a/src/main/java/io/jenkins/plugins/jwt_auth/JwtAuthSecurityRealm.java
+++ b/src/main/java/io/jenkins/plugins/jwt_auth/JwtAuthSecurityRealm.java
@@ -259,7 +259,9 @@ public class JwtAuthSecurityRealm extends SecurityRealm {
 						groups = jwtClaims.getStringListClaimValue(groupsClaimName);
 					} else {
 						groupList = jwtClaims.getClaimValueAsString(groupsClaimName);
-						groups = Arrays.asList(StringUtils.split(groupList, groupsClaimSeparator));
+						if (groupList != null) {
+							groups = Arrays.asList(StringUtils.split(groupList, groupsClaimSeparator));
+						}
 					}
 
 					if (groups == null) {

--- a/src/test/java/io/jenkins/plugins/jwt_auth/JwtAuthSecurityRealmTest.java
+++ b/src/test/java/io/jenkins/plugins/jwt_auth/JwtAuthSecurityRealmTest.java
@@ -291,6 +291,24 @@ public class JwtAuthSecurityRealmTest {
                         true, // is allowed!
                         "email",
                         "fullName"
+                },
+                // groups claim does not exist
+                new Object[]{
+                        "http://localhost:9191/.well-known/jwks.json",
+                        "issuer1,test",
+                        "audience1,testaudience",
+                        "other-header-NAME",
+                        "username",
+                        "groupsNotExist",
+                        "",
+                        ecJwk,
+                        "testuser",
+                        "testuser",
+                        null,
+                        null,
+                        false,
+                        "email",
+                        "fullName"
                 }
         );
 
@@ -388,6 +406,10 @@ public class JwtAuthSecurityRealmTest {
             groups.addAll(Jenkins.ANONYMOUS2.getAuthorities());
         } else {
             groups.add(SecurityRealm.AUTHENTICATED_AUTHORITY2);
+        }
+
+        if (expectedGroups == null) {
+        	expectedGroups = Arrays.asList();
         }
 
         for (String groupName : expectedGroups) {


### PR DESCRIPTION
The groups claim can now be missing without causing crash.

### Testing done

Test case added to JwtAuthSecurityRealmTest.java.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
