### PR TITLE
Allow loginUrl override for JWT auth

### DIFF
--- a/src/main/java/io/jenkins/plugins/jwt_auth/JwtAuthSecurityRealm.java
+++ b/src/main/java/io/jenkins/plugins/jwt_auth/JwtAuthSecurityRealm.java
@@ -89,6 +89,7 @@ public class JwtAuthSecurityRealm extends SecurityRealm {
 	private final boolean allowVerificationFailures;
 	private final String emailClaimName;
 	private final String fullNameClaim;
+        private final String loginUrl;
 
 	@DataBoundConstructor
 	public JwtAuthSecurityRealm(
@@ -102,7 +103,8 @@ public class JwtAuthSecurityRealm extends SecurityRealm {
 			int leewaySeconds,
 			boolean allowVerificationFailures,
 			String emailClaimName,
-			String fullNameClaim
+			String fullNameClaim,
+                        String loginUrl
 	) {
 		super();
 		this.headerName = Util.fixEmptyAndTrim(headerName);
@@ -116,6 +118,7 @@ public class JwtAuthSecurityRealm extends SecurityRealm {
 		this.allowVerificationFailures = allowVerificationFailures;
 		this.emailClaimName = Util.fixEmptyAndTrim(emailClaimName);
 		this.fullNameClaim = Util.fixEmptyAndTrim(fullNameClaim);
+		this.loginUrl = Util.fixEmpty(loginUrl);
 	}
 
 	/**
@@ -450,5 +453,9 @@ public class JwtAuthSecurityRealm extends SecurityRealm {
 
 	public String getFullNameClaim() {
 		return fullNameClaim;
+	}
+
+	public String getLoginUrl() {
+		return loginUrl;
 	}
 }

--- a/src/test/java/io/jenkins/plugins/jwt_auth/ConfigurationAsCodeTest.java
+++ b/src/test/java/io/jenkins/plugins/jwt_auth/ConfigurationAsCodeTest.java
@@ -65,6 +65,9 @@ public class ConfigurationAsCodeTest {
         "name",
         jwtAuthSecurityRealm.getFullNameClaim()
     );
-
+    assertEquals(
+        "http://jwks-host/login",
+        jwtAuthSecurityRealm.getLoginUrl()
+    );
   }
 }

--- a/src/test/java/io/jenkins/plugins/jwt_auth/JwtAuthSecurityRealmTest.java
+++ b/src/test/java/io/jenkins/plugins/jwt_auth/JwtAuthSecurityRealmTest.java
@@ -82,6 +82,7 @@ public class JwtAuthSecurityRealmTest {
     private String groupListString;
     private String emailClaimName;
     private String fullNameClaim;
+    private String loginUrl;
 
     @Before
     public void prepare() {
@@ -128,7 +129,8 @@ public class JwtAuthSecurityRealmTest {
                     null,
                     false,
                     "",
-                    ""
+                    "",
+                    "login"
                 },
                 // normal use case with rsa key
                 new Object[]{
@@ -146,7 +148,8 @@ public class JwtAuthSecurityRealmTest {
                         null,
                         false,
                         "email",
-                        "fullName"
+                        "fullName",
+                        "login"
                 },
                 // normal use case with ec key
                 new Object[]{
@@ -164,7 +167,8 @@ public class JwtAuthSecurityRealmTest {
                         null,
                         false,
                         "email",
-                        "fullName"
+                        "fullName",
+                        "login"
                 },
                 // ec key, group list as string with separator
                 new Object[]{
@@ -182,7 +186,8 @@ public class JwtAuthSecurityRealmTest {
                         "group1|group2|group3",
                         false,
                         "email",
-                        "fullName"
+                        "fullName",
+                        "login"
                 },
                 // Azure passes groups as [group1, group2, group3]
                 new Object[]{
@@ -200,7 +205,8 @@ public class JwtAuthSecurityRealmTest {
                         "[group1, group2, group3]",
                         false,
                         "email",
-                        "fullName"
+                        "fullName",
+                        "login"
                 },
                 // no jwks defined in the realm
                 new Object[]{
@@ -218,7 +224,8 @@ public class JwtAuthSecurityRealmTest {
                         null,
                         false,
                         "email",
-                        "fullName"
+                        "fullName",
+                        "login"
                 },
                 // audience and issuer matching
                 new Object[]{
@@ -236,7 +243,8 @@ public class JwtAuthSecurityRealmTest {
                         null,
                         false,
                         "email",
-                        "fullName"
+                        "fullName",
+                        "login"
                 },
                 // audience not matching -> anonymous
                 new Object[]{
@@ -254,7 +262,8 @@ public class JwtAuthSecurityRealmTest {
                         null,
                         false,
                         "email",
-                        "fullName"
+                        "fullName",
+                        "login"
                 },
                 // issuer not matching
                 new Object[]{
@@ -272,7 +281,8 @@ public class JwtAuthSecurityRealmTest {
                         null,
                         false,
                         "email",
-                        "fullName"
+                        "fullName",
+                        "login"
                 },
                 // issuer not matching, but verification errors are allowed
                 new Object[]{
@@ -290,7 +300,8 @@ public class JwtAuthSecurityRealmTest {
                         null,
                         true, // is allowed!
                         "email",
-                        "fullName"
+                        "fullName",
+                        "login"
                 }
         );
 
@@ -311,7 +322,8 @@ public class JwtAuthSecurityRealmTest {
             String groupListString,
             boolean allowVerificationFailures,
             String emailClaimName,
-            String fullNameClaim
+            String fullNameClaim,
+            String loginUrl
     ) {
         this.jwksUrl = jwksUrl;
         this.acceptableIssuer = acceptableIssuer;
@@ -328,6 +340,7 @@ public class JwtAuthSecurityRealmTest {
         this.allowVerificationFailures = allowVerificationFailures;
         this.emailClaimName = emailClaimName;
         this.fullNameClaim = fullNameClaim;
+        this.loginUrl = loginUrl;
     }
 
     @Test
@@ -344,7 +357,8 @@ public class JwtAuthSecurityRealmTest {
                 0,
                 allowVerificationFailures,
                 emailClaimName,
-                fullNameClaim
+                fullNameClaim,
+                loginUrl
         );
         jenkins.setSecurityRealm(realm);
 

--- a/src/test/resources/configuration-as-code.yml
+++ b/src/test/resources/configuration-as-code.yml
@@ -12,3 +12,4 @@ jenkins:
       allowVerificationFailures: true
       emailClaimName: email
       fullNameClaim: name
+      loginUrl: http://jwks-host/login


### PR DESCRIPTION
When using JWT, allow the setting of the login URL so that it can point at the source of login for the JWT token.

Allows control over the login to handle https://github.com/jenkinsci/jwt-auth-plugin/issues/70.

### Testing done

Automated tests updated and pass.

Plugin tested against Jenkins 2.440.1.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
